### PR TITLE
Upgrade jackcess, sqlite-jdbc, and other dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
         <dependency>
             <groupId>com.healthmarketscience.jackcess</groupId>
             <artifactId>jackcess</artifactId>
-            <version>2.1.0</version>
+            <version>3.0.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <slf4j.version>1.7.12</slf4j.version>
+        <slf4j.version>1.7.26</slf4j.version>
     </properties>
 
     <scm>
@@ -164,12 +164,12 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.8.7</version>
+            <version>3.25.2</version>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.48</version>
+            <version>1.72</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -185,7 +185,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.3</version>
+            <version>1.2.3</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/src/test/java/net/kockert/access/export/IndexStub.java
+++ b/src/test/java/net/kockert/access/export/IndexStub.java
@@ -48,6 +48,11 @@ public class IndexStub implements Index {
     }
 
     @Override
+    public int getColumnCount() {
+        return columns.size();
+    }
+
+    @Override
     public List<? extends Column> getColumns() {
         return columns;
     }
@@ -65,6 +70,11 @@ public class IndexStub implements Index {
     @Override
     public boolean isUnique() {
         return unique;
+    }
+
+    @Override
+    public boolean isRequired() {
+        return false;
     }
 
     @Override

--- a/src/test/java/net/kockert/access/export/RelationshipStub.java
+++ b/src/test/java/net/kockert/access/export/RelationshipStub.java
@@ -78,6 +78,11 @@ public class RelationshipStub implements Relationship {
     }
 
     @Override
+    public boolean cascadeNullOnDelete() {
+        return false;
+    }
+
+    @Override
     public boolean isLeftOuterJoin() {
         return false;
     }
@@ -85,6 +90,11 @@ public class RelationshipStub implements Relationship {
     @Override
     public boolean isRightOuterJoin() {
         return false;
+    }
+
+    @Override
+    public JoinType getJoinType() {
+        return JoinType.LEFT_OUTER;
     }
 
 }

--- a/src/test/java/net/kockert/access/export/TableStub.java
+++ b/src/test/java/net/kockert/access/export/TableStub.java
@@ -15,6 +15,8 @@ public class TableStub implements Table {
     private List<IndexStub> indexes;
     private List<ColumnStub> columns;
 
+    private boolean allowAutoNumberInsert;
+
     public TableStub(String name) {
         this.name = name;
         indexes = new ArrayList<>();
@@ -76,6 +78,16 @@ public class TableStub implements Table {
     @Override
     public void setErrorHandler(ErrorHandler newErrorHandler) {
 
+    }
+
+    @Override
+    public boolean isAllowAutoNumberInsert() {
+        return allowAutoNumberInsert;
+    }
+
+    @Override
+    public void setAllowAutoNumberInsert(Boolean allowAutoNumInsert) {
+        this.allowAutoNumberInsert = allowAutoNumInsert;
     }
 
     @Override


### PR DESCRIPTION
Tests remain green.  The CSV and SQLite exports were exactly the same, after the jackcess upgrade, according to manual testing with a local 1GB MS Access 2000 database.  The SQLite export file changed slightly after the sqlite-jdbc upgrade, as might be expected, but spot checking showed it to be correct.
